### PR TITLE
Update config to fix table of contents formatting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,3 +46,8 @@ pygmentsCodeFences = true
   [[menu.developer]]
     name = "Frontend"
     weight = 40
+    
+[markup]
+  [markup.tableOfContents]
+    startLevel = 1
+    endLevel = 1


### PR DESCRIPTION
Fix formatting of **Page Contents** list. Issue was due to change in Hugo markdown renderer.