### PR TITLE
Remove 'Replace Files' in samples API docs

### DIFF
--- a/content/docs/developer/api/samples.md
+++ b/content/docs/developer/api/samples.md
@@ -345,12 +345,6 @@ Edit the access rights for a sample.
 | `404`  | Not found                             | `sample_id` in URL does not exist                     |
 | `422`  | Invalid input                         | request body JSON failed validation                   |
 
-# Replace Files
-
-{{< right write >}} {{< new_in "v3.4.0" >}}
-
-Replace old trimmed files with original raw files.
-
 # Remove
 
 {{< administrator_owner >}}


### PR DESCRIPTION
Remove **Replace Files** section in sample API docs as this feature will not be supported in Virtool 5.