### PR TITLE
Add Job API section in developer docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,53 +1,57 @@
 baseURL = "/"
 languageCode = "en-us"
-title = "Virtool"
-theme = "virtool"
 staticDir = ["static"]
+theme = "virtool"
+title = "Virtool"
 
 enableGitInfo = true
 pygmentsCodeFences = true
 
 [sitemap]
-  filename = "sitemap.xml"
+filename = "sitemap.xml"
 
 [outputs]
-  home = ["HTML"]
-  page = ["HTML"]
+home = ["HTML"]
+page = ["HTML"]
 
 [menu]
-  [[menu.manual]]
-    name = "Getting Started"
-    weight = 10
-    
-  [[menu.manual]]
-    name = "Tutorials"
-    weight = 20
+[[menu.manual]]
 
-  [[menu.manual]]
-    name = "User Guide"
-    weight = 30
+name = "Getting Started"
+weight = 10
+[[menu.manual]]
+name = "Tutorials"
+weight = 20
 
-  [[menu.manual]]
-    name = "Science"
-    weight = 40
+[[menu.manual]]
+name = "User Guide"
+weight = 30
 
-  [[menu.developer]]
-    name = "Contributing"
-    weight = 10
+[[menu.manual]]
+name = "Science"
+weight = 40
 
-  [[menu.developer]]
-    name = "API"
-    weight = 20
+[[menu.developer]]
+name = "Contributing"
+weight = 10
 
-  [[menu.developer]]
-    name = "Backend"
-    weight = 30
+[[menu.developer]]
+name = "API"
+weight = 20
 
-  [[menu.developer]]
-    name = "Frontend"
-    weight = 40
-    
+[[menu.developer]]
+name = "Job API"
+weight = 30
+
+[[menu.developer]]
+name = "Backend"
+weight = 40
+
+[[menu.developer]]
+
+name = "Frontend"
+weight = 50
 [markup]
-  [markup.tableOfContents]
-    startLevel = 1
-    endLevel = 1
+[markup.tableOfContents]
+endLevel = 1
+startLevel = 1

--- a/content/docs/developer/job_api/analyses.md
+++ b/content/docs/developer/job_api/analyses.md
@@ -1,0 +1,183 @@
+---
+title: "Analyses"
+description: "Query and modify analyses"
+menu:
+    developer:
+        identifier: job_api_analyses
+        parent: Job API
+        
+---
+
+Analyses are the results of a given Virtool analytical workflows on a single sample.
+
+# Get
+
+Get a complete analysis document.
+
+Only analysis jobs have access to this endpoint and only on the analysis the are running.
+
+{{< endpoint "GET" "/api/analyses/:id" >}}
+
+## Example
+
+{{< request "GET" "/api/analyses/uskrqsxm" />}}
+
+## Response
+
+{{< response "Status: 200 OK" >}}
+
+```json
+{
+    "id": "uskrqsxm",
+    "created_at": "2017-10-03T21:35:54.813000Z",
+    "job": {
+        "id": "afovbrnx"
+    },
+    "workflow": "pathoscope_bowtie",
+    "sample": {
+        "id": "kigvhuql",
+        "name": "Test 1"
+    },
+    "index": {
+        "id": "qldihken",
+        "version": 0
+    },
+    "user": {
+        "id": "igboyes"
+    },
+    "subtractions": [
+      {
+        "id": "yhxoynb0",
+        "name": "Arabidopsis Thaliana"
+      }
+    ],
+    "ready": false
+}
+```
+
+{{< /response >}}
+
+## Errors
+
+| Status | Message             | Reason                          |
+| :----- | :------------------ | :------------------------------ |
+| `403`  | Insufficient rights | Job read rights on the analysis |
+| `404`  | Not found           | The analysis does not exist     |
+
+
+# Upload File
+
+**NOT IMPLEMENTED**
+
+Upload a file that should be persisted with the analysis.
+
+Uploaded files will be available for download via the API or browser client.
+
+{{< endpoint "POST" "/api/analyses/:id/files" >}}
+
+## Parameters
+
+| Name | Type   | Default   | Description                             |
+| :--- | :----- | :-------- | :-------------------------------------- |
+| name | string |           | an original name to retain for the file |
+| type | string | `unknown` | the upload type                         |
+
+
+# Finalize
+
+Finish and set the results of an analysis.
+
+Sets the `results` field with the passed results object and the `ready` field to `true`. After this request succeeds, the analysis is viewable in the browser client.
+
+This request will fail with `409` on analyses that have already been finalized.
+
+{{< endpoint "PATCH" "/api/analyses/:id" >}}
+
+## Parameters
+
+| Name    | Type   | Required | Description                                       |
+| :------ | :----- | :------- | :------------------------------------------------ |
+| results | object | Yes      | A freeform object that stores the analysis result |
+
+## Example
+
+{{< request "PATCH" "/api/analyses/uskrqsxm" >}}
+```json
+{
+    "results": {
+        "foo": "bar"
+    }
+}
+```
+{{< /request >}}
+
+## Response
+
+{{< response "Status: 200 OK" >}}
+```json
+{
+    "id": "uskrqsxm",
+    "created_at": "2017-10-03T21:35:54.813000Z",
+    "job": {
+        "id": "afovbrnx"
+    },
+    "workflow": "pathoscope_bowtie",
+    "sample": {
+        "id": "kigvhuql",
+        "name": "Test 1"
+    },
+    "index": {
+        "id": "qldihken",
+        "version": 0
+    },
+    "user": {
+        "id": "igboyes"
+    },
+    "subtractions": [
+      {
+        "id": "yhxoynb0",
+        "name": "Arabidopsis Thaliana"
+      }
+    ],
+    "ready": true,
+    "results": {
+        "foo": "bar"
+    }
+}
+```
+{{</ response >}}
+
+## Errors
+
+| Status | Message                                     | Reason                                                 |
+| :----- | :------------------------------------------ | :----------------------------------------------------- |
+| `403`  | Insufficient rights                         | The job does not have the modify right on the analysis |
+| `404`  | Not found                                   | Analysis does not exist                                |
+| `409`  | There is already a result for this analysis | Analysis job is already finalized                      |
+
+
+# Remove
+
+**NOT IMPLEMENTED**
+
+Remove an incomplete analysis.
+
+Finalized analyses cannot be removed over the jobs API. This must be done via the public API or browser client. Jobs can only remove the analysis they are running.
+
+{{< endpoint "DELETE" "/api/analyses/:id" >}}
+
+## Example
+
+{{< request "DELETE" "/api/analyses/:analysis_id" />}}
+
+## Response
+
+{{< response "Status: 204 No content" />}}
+
+## Errors
+
+| Status | Message               | Reason                                                                                         |
+| :----- | :-------------------- | :--------------------------------------------------------------------------------------------- |
+| `403`  | Insufficient rights   | Client does not have the required sample rights to remove the analysis                         |
+| `404`  | Not found             | Analysis does not exist                                                                        |
+| `409`  | Analysis is finalized | Analysis job is finalized with `ready` set `true`. It can only be removed from the regular API |

--- a/content/docs/developer/job_api/hmm.md
+++ b/content/docs/developer/job_api/hmm.md
@@ -1,0 +1,85 @@
+---
+title: "HMM"
+description: "Manage and query HMM annotations and files."
+menu:
+    developer:
+        identifier: job_api_hmm
+        parent: Job API
+---
+
+# Get {#get}
+
+Get the complete representation of a single HMM annotation.
+
+{{< endpoint "GET" "/api/hmms/:id" >}}
+
+## Example
+
+{{< request "GET" "/api/hmms/zltnktou" />}}
+
+## Response
+
+{{< response "Status: 200 OK" >}}
+
+```json
+{
+    "families": {
+        "None": 1,
+        "Geminiviridae": 203
+    },
+    "total_entropy": 72.08,
+    "length": 136,
+    "cluster": 3,
+    "entries": [
+        {
+            "accession": "NP_040323.1",
+            "gi": "9626084",
+            "organism": "Pepper huasteco yellow vein virus",
+            "name": "AL2 protein"
+        },
+        {
+            "accession": "NP_044924.1",
+            "gi": "9629639",
+            "organism": "Tomato mottle Taino virus",
+            "name": "transactivator protein"
+        }
+    ],
+    "genera": {
+        "Begomovirus": 197,
+        "Topocuvirus": 1,
+        "None": 2,
+        "Curtovirus": 4
+    },
+    "mean_entropy": 0.53,
+    "count": 216,
+    "names": ["AC2 protein", "C2 protein", "AC2"],
+    "hidden": false,
+    "id": "zltnktou"
+}
+```
+
+{{< /response >}}
+
+## Errors
+
+| Status | Message   | Reason                        |
+| :----- | :-------- | :---------------------------- |
+| `404`  | Not found | HMM annotation does not exist |
+
+
+# Download Profiles
+
+**NOT IMPLEMENTED**
+
+Get the `profiles.hmm` used in analysis workflows requiring `hmmer`.
+
+{{< endpoint "GET" "/download/hmms/profiles.hmm" >}}
+
+## Example
+
+{{< request "GET" "/download/hmms/profiles.hmm" />}}
+
+## Response
+
+{{< response "Status: 200 OK" />}}
+

--- a/content/docs/developer/job_api/indexes.md
+++ b/content/docs/developer/job_api/indexes.md
@@ -1,0 +1,77 @@
+---
+title: "Indexes"
+description: "Query and create virus indexes."
+menu:
+    developer:
+        identifier: job_api_indexes
+        parent: Job API
+---
+
+# Get
+
+Get the complete representation of an index.
+
+{{< endpoint "GET" "/api/indexes/:id" >}}
+
+## Example
+
+{{< request "GET" "/api/indexes/jiwncaqr" />}}
+
+## Response
+
+{{< response "Status: 200 OK" >}}
+
+```json
+{
+	"version": 0,
+	"created_at": "2018-02-01T00:28:49.798000Z",
+	"manifest": {
+		"c93ec9a9": 0,
+        ...
+	},
+	"ready": false,
+	"user": {
+		"id": "igboyes"
+	},
+	"job": {
+		"id": "wwssuhhy"
+	},
+	"id": "jiwncaqr",
+	"contributors": [
+		{
+			"id": "igboyes",
+			"count": 1419
+		}
+	],
+	"change_count": 1419
+}
+```
+
+{{< /response >}}
+
+## Errors
+
+| Status | Message             | Reason                                         |
+| :----- | :------------------ | :--------------------------------------------- |
+| `403`  | Insufficient rights | The job does not have read rights on the index |
+| `404`  | Not found           | The index does not exist                       |
+
+# Upload File
+
+**Not Implemented**
+
+Upload files that
+
+# Finalize
+
+**Not Implemented**
+
+Finish an index build job.
+
+{{< endpoint "PATCH" "/api/indexes/:id" >}}
+
+## Example
+
+```
+PATCH /api/indexes/:id
+```

--- a/content/docs/developer/job_api/jobs.md
+++ b/content/docs/developer/job_api/jobs.md
@@ -1,0 +1,127 @@
+---
+title: "Jobs"
+description: "Query, cancel, and remove jobs."
+menu:
+    developer:
+        identifier: job_api_jobs
+        parent: Job API
+---
+
+# Get
+
+Get the complete representation for a single job.
+
+Jobs can only retrieve data for themselves.
+
+{{< endpoint "GET" "/api/jobs/:id" >}}
+
+## Example
+
+{{< request "GET" "/api/jobs/zzpugkyt" />}}
+
+## Response
+
+{{< response "Status: 200 OK" >}}
+```json
+{
+	"task": "create_subtraction",
+	"args": {
+		"subtraction_id": "Thale",
+		"file_id": "vlekszor-ATgenomeTAIR9.171"
+	},
+	"proc": 2,
+	"mem": 4,
+	"user": {
+		"id": "igboyes"
+	},
+	"status": [
+		{
+			"state": "waiting",
+			"stage": null,
+			"error": null,
+			"progress": 0,
+			"timestamp": "2018-02-06T22:15:52.664000Z"
+		},
+		{
+			"state": "running",
+			"stage": "mk_subtraction_dir",
+			"error": null,
+			"progress": 0.2,
+			"timestamp": "2018-02-06T22:16:11.166000Z"
+		},
+		{
+			"state": "running",
+			"stage": "set_stats",
+			"error": null,
+			"progress": 0.4,
+			"timestamp": "2018-02-06T22:16:11.169000Z"
+		},
+		{
+			"state": "running",
+			"stage": "bowtie_build",
+			"error": null,
+			"progress": 0.6,
+			"timestamp": "2018-02-06T22:16:15.637000Z"
+		}
+	],
+	"id": "zzpugkyt"
+}
+```
+{{< /response >}}
+
+## Errors
+
+| Status | Message             | Reason                                                         |
+| :----- | :------------------ | :------------------------------------------------------------- |
+| `403`  | Insufficient rights | The job does not have the right to read jobs other than itself |
+| `404`  | Not found           | The job does not exist                                         |
+
+# Push Status
+
+Push a status record when the state of a job changes.
+
+Jobs can only push status to their on job resource.
+
+{{< endpoint "POST" "/api/jobs/:id/status" >}}
+
+
+## Parameters
+| Name     | Type   | Required | Description                                                            |
+| :------- | :----- | :------- | :--------------------------------------------------------------------- |
+| state    | string | Yes      | the job state (`waiting`, `running`, `complete`, `cancelled`, `error`) |
+| stage    | string | Yes      | The stage (step) the job is at                                         |
+| error    | string | No       | An error if the job encountered one                                    |
+| progress | string | Yes      | The progress of the job as an integer (0 - 100)                        |
+
+## Example
+
+{{< request "POST" "/api/jobs/zzpugkyt/status" >}}
+```json
+{
+    "state": "running",
+    "stage": "bowtie_build",
+    "progress": 40
+}
+```
+{{</ request >}}
+
+## Response
+
+{{< response "Status: 200 OK" >}}
+```json
+{
+    "state": "running",
+    "stage": "bowtie_build",
+    "error": null,
+    "progress": 40,
+    "timestamp": "2018-02-06T22:16:15.637000Z"
+}
+```
+{{< /response >}}
+
+## Errors
+
+| Status | Message             | Reason                                                         |
+| :----- | :------------------ | :------------------------------------------------------------- |
+| `403`  | Insufficient rights | The job does not have the right to read jobs other than itself |
+| `404`  | Not found           | The job does not exist                                         |


### PR DESCRIPTION
This section will document the API endpoints available to jobs.

Added rough sections for:
* analyses
* hmm
* indexes
* jobs
