### PR TITLE
Fix latest software release in Downloads page

### DIFF
--- a/layouts/downloads/single.html
+++ b/layouts/downloads/single.html
@@ -8,7 +8,7 @@
       <p class="subtitle">
         Download and run the latest release of the Virtool software.
       </p>
-      {{ partial "release.html" (dict "latest" .Site.Data.releases3.virtool.latest "label" "Virtool" "slug" "virtool/virtool") }}
+      {{ partial "release.html" (dict "latest" .Site.Data.releases4.virtool.latest "label" "Virtool" "slug" "virtool/virtool") }}
 
       <h2>Official References</h2>
       <p class="subtitle">


### PR DESCRIPTION
Was not showing latest releases after v4.1.0