### PR TITLE
Add documentation for index file uploading

### DIFF
--- a/content/docs/developer/api/uploads.md
+++ b/content/docs/developer/api/uploads.md
@@ -13,7 +13,7 @@ These endpoints are used to upload files to Virtool for use in sample, subtracti
 
 Uploads a file to be used in Virtool.
 
-The upload request is expected to use the encoding type `multipart/form-data`. The upload file should be accessible under the `file` key.
+The upload request is expected to use the encoding type `multipart/form-data`. The file should be made accessible under the `file` key.
 
 Additional input including the file's `name` and `type` should be included in the query string.
 

--- a/content/docs/developer/job_api/indexes.md
+++ b/content/docs/developer/job_api/indexes.md
@@ -58,9 +58,48 @@ Get the complete representation of an index.
 
 # Upload File
 
-**Not Implemented**
+{{< permission upload_file >}}
 
-Upload files that
+Upload files that can be used in an index build job.
+
+The upload request is expected to use the encoding type `multipart/form-data`. The upload file should be accessible under the `file` key.
+
+{{< endpoint "POST" "/api/indexes/:id/files" >}}
+
+## Parameters
+
+| Name   | Type   | Required  | Description                                                                             |
+| :---   | :----- | :-------- | :-------------------------------------------------------------------------------------- |
+| name   | string | Yes       | Name of a index file to upload (one of: `reference.json.gz`, `reference.fa.gz`, `reference.1.bt2`, `reference.2.bt2`, `reference.3.bt2`, `reference.4.bt4`, `reference.rev.1.bt2`, `reference.rev.2.bt2`)                                                 |
+
+## Example
+
+{{< request "POST" "/api/indexes/uskrqsxm/files?name=reference.fa.gz" >}}
+{{< /request >}}
+
+## Response
+
+{{< response "Status: 201 OK" >}}
+```json
+{
+  "id": 1,
+  "name": "reference.fa.gz",
+  "reference": "bar",
+  "size": 7205747,
+  "type": "fasta"
+}
+```
+{{</ response >}}
+
+## Errors
+
+| Status | Message                     | Reason                                                                 |
+| :----- | :-------------------------- | :--------------------------------------------------------------------- |
+| `400`  | Unsupported index file name | Given file is not one of the accepted file names, see `name` parameter |
+| `403`  | Insufficient rights         | Upload file rights required                                            |
+| `404`  | Not found                   | Index does not exist                                                   |
+| `409`  | File name already exists    | File is already associated with this index                             |
+| `422`  | Invalid query               | `name` is a required field
 
 # Finalize
 
@@ -69,9 +108,3 @@ Upload files that
 Finish an index build job.
 
 {{< endpoint "PATCH" "/api/indexes/:id" >}}
-
-## Example
-
-```
-PATCH /api/indexes/:id
-```

--- a/content/docs/developer/job_api/indexes.md
+++ b/content/docs/developer/job_api/indexes.md
@@ -58,19 +58,27 @@ Get the complete representation of an index.
 
 # Upload File
 
-{{< permission upload_file >}}
+Upload a file that should be persisted with an index.
 
-Upload files that can be used in an index build job.
+The upload request is expected to use the encoding type `multipart/form-data`. The file data should be made accessible under the `file` key.
 
-The upload request is expected to use the encoding type `multipart/form-data`. The upload file should be accessible under the `file` key.
+The name of the file to be uploaded must be be one of the following:
+* `reference.json.gz`
+* `reference.fa.gz`
+* `reference.1.bt2`
+* `reference.2.bt2`
+* `reference.3.bt2`
+* `reference.4.bt4`
+* `reference.rev.1.bt2`
+* `reference.rev.2.bt2`
 
 {{< endpoint "POST" "/api/indexes/:id/files" >}}
 
 ## Parameters
 
-| Name   | Type   | Required  | Description                                                                             |
-| :---   | :----- | :-------- | :-------------------------------------------------------------------------------------- |
-| name   | string | Yes       | Name of a index file to upload (one of: `reference.json.gz`, `reference.fa.gz`, `reference.1.bt2`, `reference.2.bt2`, `reference.3.bt2`, `reference.4.bt4`, `reference.rev.1.bt2`, `reference.rev.2.bt2`)                                                 |
+| Name   | Type   | Required  | Description                                                                |
+| :---   | :----- | :-------- | :------------------------------------------------------------------------- |
+| name   | string | Yes       | Name of a index file to upload (must be one of the file names listed above)|
 
 ## Example
 


### PR DESCRIPTION
Didn't realize that there isn't an endpoint to finalize index builds (yet?), so I left it unimplemented.